### PR TITLE
Better better select

### DIFF
--- a/lib/app/modules/LibraryList/views/character_classes_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/character_classes_library_list_view.dart
@@ -45,15 +45,6 @@ class CharacterClassesLibraryListView extends GetView<LibraryListController<Char
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
-          /*
-          if (data.selectable)
-            ElevatedButton.icon(
-              style: ButtonThemes.primaryElevated(context),
-              onPressed: data.onToggle,
-              label: data.label,
-              icon: data.icon,
-            ),
-            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/character_classes_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/character_classes_library_list_view.dart
@@ -4,7 +4,6 @@ import 'package:dungeon_paper/app/data/services/repository_service.dart';
 import 'package:dungeon_paper/app/model_utils/model_pages.dart';
 import 'package:dungeon_paper/app/modules/LibraryList/controllers/library_list_controller.dart';
 import 'package:dungeon_paper/app/modules/LibraryList/views/library_list_view.dart';
-import 'package:dungeon_paper/app/themes/button_themes.dart';
 import 'package:dungeon_paper/app/widgets/cards/character_class_card.dart';
 import 'package:dungeon_paper/app/widgets/menus/entity_edit_menu.dart';
 import 'package:flutter/material.dart';
@@ -35,6 +34,7 @@ class CharacterClassesLibraryListView extends GetView<LibraryListController<Char
         showDice: false,
         showStar: false,
         highlightWords: data.highlightWords,
+        onExpansion: data.onExpansion,
         actions: [
           EntityEditMenu(
             onEdit: data.onUpdate != null

--- a/lib/app/modules/LibraryList/views/character_classes_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/character_classes_library_list_view.dart
@@ -45,6 +45,7 @@ class CharacterClassesLibraryListView extends GetView<LibraryListController<Char
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
+          /*
           if (data.selectable)
             ElevatedButton.icon(
               style: ButtonThemes.primaryElevated(context),
@@ -52,6 +53,7 @@ class CharacterClassesLibraryListView extends GetView<LibraryListController<Char
               label: data.label,
               icon: data.icon,
             ),
+            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/items_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/items_library_list_view.dart
@@ -42,6 +42,7 @@ class ItemsLibraryListView extends GetView<LibraryListController<Item, ItemFilte
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
+          /*
           if (data.selectable)
             ElevatedButton.icon(
               style: ButtonThemes.primaryElevated(context),
@@ -49,6 +50,7 @@ class ItemsLibraryListView extends GetView<LibraryListController<Item, ItemFilte
               label: data.label,
               icon: data.icon,
             )
+            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/items_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/items_library_list_view.dart
@@ -43,15 +43,6 @@ class ItemsLibraryListView extends GetView<LibraryListController<Item, ItemFilte
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
-          /*
-          if (data.selectable)
-            ElevatedButton.icon(
-              style: ButtonThemes.primaryElevated(context),
-              onPressed: data.onToggle,
-              label: data.label,
-              icon: data.icon,
-            )
-            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/items_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/items_library_list_view.dart
@@ -32,6 +32,7 @@ class ItemsLibraryListView extends GetView<LibraryListController<Item, ItemFilte
         showStar: false,
         highlightWords: data.highlightWords,
         hideCount: true,
+        onExpansion: data.onExpansion,
         actions: [
           EntityEditMenu(
             onEdit: data.onUpdate != null

--- a/lib/app/modules/LibraryList/views/library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/library_list_view.dart
@@ -19,7 +19,6 @@ class CardBuilderData<T> {
   final bool selected;
   final bool selectable;
   final CancellableValueChanged<bool>? onExpansion;
-  final Widget icon;
   final void Function(T item)? onUpdate;
   final void Function(T item)? onDelete;
   final List<String> highlightWords;
@@ -29,7 +28,6 @@ class CardBuilderData<T> {
     required this.selected,
     required this.selectable,
     this.onExpansion,
-    required this.icon,
     required this.highlightWords,
     this.onUpdate,
     this.onDelete,
@@ -183,17 +181,6 @@ class LibraryListView<T extends WithMeta, F extends EntityFilters<T>> extends Ge
                       }
                     }
                   : null,
-              icon: Icon(
-                enabled
-                    ? !selected
-                        ? controller.multiple
-                            ? Icons.add
-                            : Icons.check
-                        : Icons.remove
-                    : controller.multiple
-                        ? Icons.add
-                        : Icons.check,
-              ),
               onUpdate:
                   group == FiltersGroup.my ? (item) => controller.saveCustomItem(controller.storageKey, item) : null,
               onDelete: group == FiltersGroup.my

--- a/lib/app/modules/LibraryList/views/library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/library_list_view.dart
@@ -170,7 +170,6 @@ class LibraryListView<T extends WithMeta, F extends EntityFilters<T>> extends Ge
               onExpansion: selectable
                   ? (collapsed) {
                       final selected = controller.isSelected(item);
-                      print('mul ${controller.multiple}, col $collapsed, sel $selected');
                       if (controller.multiple) {
                         if (collapsed) return false;
                         controller.toggleItem(item, !selected);

--- a/lib/app/modules/LibraryList/views/library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/library_list_view.dart
@@ -18,9 +18,8 @@ class CardBuilderData<T> {
   final T item;
   final bool selected;
   final bool selectable;
-  final bool multiple;
+  final CancellableValueChanged<bool>? onExpansion;
   final Widget icon;
-  final void Function()? onToggle;
   final void Function(T item)? onUpdate;
   final void Function(T item)? onDelete;
   final List<String> highlightWords;
@@ -29,10 +28,9 @@ class CardBuilderData<T> {
     required this.item,
     required this.selected,
     required this.selectable,
-    required this.multiple,
+    this.onExpansion,
     required this.icon,
     required this.highlightWords,
-    this.onToggle,
     this.onUpdate,
     this.onDelete,
   });
@@ -165,13 +163,27 @@ class LibraryListView<T extends WithMeta, F extends EntityFilters<T>> extends Ge
           final selected = controller.isSelected(item);
           final enabled = controller.isEnabled(item);
           final selectable = controller.selectable;
-          final onToggle = enabled ? () => controller.toggleItem(item, !selected) : null;
           final cardData = CardBuilderData<T>(
               item: item,
               selected: selected,
               selectable: selectable && enabled,
-              onToggle: onToggle,
-              multiple: controller.multiple,
+              onExpansion: selectable
+                  ? (collapsed) {
+                      final selected = controller.isSelected(item);
+                      print('mul ${controller.multiple}, col $collapsed, sel $selected');
+                      if (controller.multiple) {
+                        if (collapsed) return false;
+                        controller.toggleItem(item, !selected);
+                        return !selected;
+                      } else {
+                        if (!selected) {
+                          controller.toggleItem(item, true);
+                          return !collapsed;
+                        }
+                        return false;
+                      }
+                    }
+                  : null,
               icon: Icon(
                 enabled
                     ? !selected

--- a/lib/app/modules/LibraryList/views/library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/library_list_view.dart
@@ -3,6 +3,7 @@ import 'package:dungeon_paper/app/modules/LibraryList/controllers/library_list_c
 import 'package:dungeon_paper/app/themes/colors.dart';
 import 'package:dungeon_paper/app/themes/themes.dart';
 import 'package:dungeon_paper/app/widgets/atoms/advanced_floating_action_button.dart';
+import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_tile.dart';
 import 'package:dungeon_paper/app/widgets/dialogs/confirm_delete_dialog.dart';
 import 'package:dungeon_paper/generated/l10n.dart';
 import 'package:flutter/material.dart';
@@ -17,7 +18,7 @@ class CardBuilderData<T> {
   final T item;
   final bool selected;
   final bool selectable;
-  final Widget label;
+  final bool multiple;
   final Widget icon;
   final void Function()? onToggle;
   final void Function(T item)? onUpdate;
@@ -28,7 +29,7 @@ class CardBuilderData<T> {
     required this.item,
     required this.selected,
     required this.selectable,
-    required this.label,
+    required this.multiple,
     required this.icon,
     required this.highlightWords,
     this.onToggle,
@@ -170,17 +171,7 @@ class LibraryListView<T extends WithMeta, F extends EntityFilters<T>> extends Ge
               selected: selected,
               selectable: selectable && enabled,
               onToggle: onToggle,
-              label: Text(
-                enabled
-                    ? !selected
-                        ? S.current.select
-                        : controller.multiple
-                            ? S.current.remove
-                            : S.current.unselect
-                    : controller.multiple
-                        ? S.current.alreadyAdded
-                        : S.current.select,
-              ),
+              multiple: controller.multiple,
               icon: Icon(
                 enabled
                     ? !selected

--- a/lib/app/modules/LibraryList/views/moves_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/moves_library_list_view.dart
@@ -6,7 +6,6 @@ import 'package:dungeon_paper/app/data/services/repository_service.dart';
 import 'package:dungeon_paper/app/model_utils/model_pages.dart';
 import 'package:dungeon_paper/app/modules/LibraryList/controllers/library_list_controller.dart';
 import 'package:dungeon_paper/app/modules/LibraryList/views/library_list_view.dart';
-import 'package:dungeon_paper/app/themes/button_themes.dart';
 import 'package:dungeon_paper/app/widgets/cards/move_card.dart';
 import 'package:dungeon_paper/app/widgets/menus/entity_edit_menu.dart';
 import 'package:flutter/material.dart';
@@ -37,6 +36,7 @@ class MovesLibraryListView extends GetView<LibraryListController<Move, MoveFilte
         showDice: false,
         showStar: false,
         highlightWords: data.highlightWords,
+        onExpansion: data.onExpansion,
         actions: [
           EntityEditMenu(
             onEdit: data.onUpdate != null
@@ -48,15 +48,6 @@ class MovesLibraryListView extends GetView<LibraryListController<Move, MoveFilte
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
-          /*
-          if (data.selectable)
-            ElevatedButton.icon(
-              style: ButtonThemes.primaryElevated(context),
-              onPressed: data.onToggle,
-              label: data.label,
-              icon: data.icon,
-            ),
-            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/moves_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/moves_library_list_view.dart
@@ -48,6 +48,7 @@ class MovesLibraryListView extends GetView<LibraryListController<Move, MoveFilte
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
+          /*
           if (data.selectable)
             ElevatedButton.icon(
               style: ButtonThemes.primaryElevated(context),
@@ -55,6 +56,7 @@ class MovesLibraryListView extends GetView<LibraryListController<Move, MoveFilte
               label: data.label,
               icon: data.icon,
             ),
+            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/notes_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/notes_library_list_view.dart
@@ -33,6 +33,7 @@ class NotesLibraryListView extends GetView<LibraryListController<Note, NoteFilte
         note: data.item,
         showStar: false,
         highlightWords: data.highlightWords,
+        onExpansion: data.onExpansion,
         actions: [
           EntityEditMenu(
             onEdit: data.onUpdate != null
@@ -43,15 +44,6 @@ class NotesLibraryListView extends GetView<LibraryListController<Note, NoteFilte
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
-          /*
-          if (data.selectable)
-            ElevatedButton.icon(
-              style: ButtonThemes.primaryElevated(context),
-              onPressed: data.onToggle,
-              label: data.label,
-              icon: data.icon,
-            ),
-            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/notes_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/notes_library_list_view.dart
@@ -43,6 +43,7 @@ class NotesLibraryListView extends GetView<LibraryListController<Note, NoteFilte
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
+          /*
           if (data.selectable)
             ElevatedButton.icon(
               style: ButtonThemes.primaryElevated(context),
@@ -50,6 +51,7 @@ class NotesLibraryListView extends GetView<LibraryListController<Note, NoteFilte
               label: data.label,
               icon: data.icon,
             ),
+            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/races_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/races_library_list_view.dart
@@ -36,6 +36,7 @@ class RacesLibraryListView extends GetView<LibraryListController<Race, RaceFilte
         showStar: false,
         showClasses: true,
         highlightWords: data.highlightWords,
+        onExpansion: data.onExpansion,
         actions: [
           EntityEditMenu(
             onEdit: data.onUpdate != null
@@ -47,15 +48,6 @@ class RacesLibraryListView extends GetView<LibraryListController<Race, RaceFilte
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
-          /*
-          if (data.selectable)
-            ElevatedButton.icon(
-              style: ButtonThemes.primaryElevated(context),
-              onPressed: data.onToggle,
-              label: data.label,
-              icon: data.icon,
-            ),
-            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/races_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/races_library_list_view.dart
@@ -47,6 +47,7 @@ class RacesLibraryListView extends GetView<LibraryListController<Race, RaceFilte
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
+          /*
           if (data.selectable)
             ElevatedButton.icon(
               style: ButtonThemes.primaryElevated(context),
@@ -54,6 +55,7 @@ class RacesLibraryListView extends GetView<LibraryListController<Race, RaceFilte
               label: data.label,
               icon: data.icon,
             ),
+            */
         ],
       ),
     );

--- a/lib/app/modules/LibraryList/views/spells_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/spells_library_list_view.dart
@@ -46,6 +46,7 @@ class SpellsLibraryListView extends GetView<LibraryListController<Spell, SpellFi
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
+          /*
           if (data.selectable)
             ElevatedButton.icon(
               style: ButtonThemes.primaryElevated(context),

--- a/lib/app/modules/LibraryList/views/spells_library_list_view.dart
+++ b/lib/app/modules/LibraryList/views/spells_library_list_view.dart
@@ -34,6 +34,7 @@ class SpellsLibraryListView extends GetView<LibraryListController<Spell, SpellFi
         showDice: false,
         showStar: false,
         highlightWords: data.highlightWords,
+        onExpansion: data.onExpansion,
         actions: [
           EntityEditMenu(
             onEdit: data.onUpdate != null
@@ -46,14 +47,6 @@ class SpellsLibraryListView extends GetView<LibraryListController<Spell, SpellFi
                 : null,
             onDelete: data.onDelete != null ? () => data.onDelete!(data.item) : null,
           ),
-          /*
-          if (data.selectable)
-            ElevatedButton.icon(
-              style: ButtonThemes.primaryElevated(context),
-              onPressed: data.onToggle,
-              label: data.label,
-              icon: data.icon,
-            ),
         ],
       ),
     );

--- a/lib/app/widgets/atoms/custom_expansion_panel.dart
+++ b/lib/app/widgets/atoms/custom_expansion_panel.dart
@@ -10,7 +10,7 @@ class CustomExpansionPanel extends StatelessWidget {
   final List<Widget> children;
   final bool? expanded;
   final bool? initiallyExpanded;
-  final void Function(bool)? onExpansion;
+  final CancellableValueChanged<bool>? onExpansion;
   final bool showArrow;
   final EdgeInsets? titlePadding;
   final EdgeInsets? childrenPadding;
@@ -57,7 +57,7 @@ class CustomExpansionPanel extends StatelessWidget {
     return CustomExpansionTile(
       key: expansionKey,
       initiallyExpanded: initiallyExpanded ?? false,
-      onExpansionChanged: (state) => onExpansion?.call(state),
+      onExpansionChanged: (state) => onExpansion?.call(state) ?? false,
       expandable: expandable,
       title: title,
       titleBuilder: titleBuilder,

--- a/lib/app/widgets/atoms/custom_expansion_tile.dart
+++ b/lib/app/widgets/atoms/custom_expansion_tile.dart
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:dungeon_paper/app/themes/themes.dart';
-import 'package:dungeon_paper/app/widgets/atoms/custom_list_tile.dart';
 import 'package:dungeon_paper/core/platform_helper.dart';
 import 'package:dungeon_paper/core/utils/math_utils.dart';
 import 'package:flutter/material.dart';
 
 const Duration _kExpand = Duration(milliseconds: 200);
+
+typedef CancellableValueChanged<T> = bool Function(T value);
 
 /// A single-line [ListTile] with an expansion arrow icon that expands or collapses
 /// the tile to reveal or hide the [children].
@@ -161,7 +162,7 @@ class CustomExpansionTile extends StatefulWidget {
   /// When the tile starts expanding, this function is called with the value
   /// true. When the tile starts collapsing, this function is called with
   /// the value false.
-  final ValueChanged<bool>? onExpansionChanged;
+  final CancellableValueChanged<bool>? onExpansionChanged;
 
   /// The color to display behind the sublist when expanded.
   final Color? backgroundColor;
@@ -310,6 +311,8 @@ class _CustomExpansionTileState extends State<CustomExpansionTile> with SingleTi
   }
 
   void _handleTap() {
+    final cancel = widget.onExpansionChanged?.call(!_isExpanded) ?? false;
+    if (cancel) return;
     setState(() {
       _isExpanded = !_isExpanded;
       if (_isExpanded) {
@@ -324,7 +327,6 @@ class _CustomExpansionTileState extends State<CustomExpansionTile> with SingleTi
       }
       PageStorage.of(context).writeState(context, _isExpanded);
     });
-    widget.onExpansionChanged?.call(_isExpanded);
   }
 
   // Platform or null affinity defaults to trailing.

--- a/lib/app/widgets/cards/character_class_card.dart
+++ b/lib/app/widgets/cards/character_class_card.dart
@@ -1,3 +1,4 @@
+import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_tile.dart';
 import 'package:dungeon_paper/generated/l10n.dart';
 import 'package:flutter/material.dart';
 
@@ -17,6 +18,7 @@ class CharacterClassCard extends StatelessWidget {
     this.expansionKey,
     this.maxContentHeight,
     this.expandable = true,
+    this.onExpansion,
     this.highlightWords = const [],
   }) : super(key: key);
 
@@ -30,6 +32,7 @@ class CharacterClassCard extends StatelessWidget {
   final PageStorageKey? expansionKey;
   final double? maxContentHeight;
   final bool expandable;
+  final CancellableValueChanged<bool>? onExpansion;
   final List<String> highlightWords;
 
   @override
@@ -39,6 +42,7 @@ class CharacterClassCard extends StatelessWidget {
       description: _buildMarkdownDescription,
       maxContentHeight: maxContentHeight,
       expandable: expandable,
+      onExpansion: onExpansion,
       expansionKey: expansionKey ?? PageStorageKey(characterClass.key),
       icon: showIcon ? Icon(characterClass.icon, size: 16) : null,
       showStar: false,

--- a/lib/app/widgets/cards/dynamic_action_card.dart
+++ b/lib/app/widgets/cards/dynamic_action_card.dart
@@ -1,5 +1,6 @@
 import 'package:dungeon_paper/app/data/models/ability_scores.dart';
 import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_panel.dart';
+import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_tile.dart';
 import 'package:dungeon_paper/app/widgets/atoms/round_roll_button.dart';
 import 'package:dungeon_paper/app/widgets/menus/entity_edit_menu.dart';
 import 'package:dungeon_paper/core/utils/markdown_highlight.dart';
@@ -50,7 +51,7 @@ class DynamicActionCard extends StatefulWidget {
   final Widget? unstarredIcon;
   final bool starred;
   final bool? initiallyExpanded;
-  final void Function(bool)? onExpansion;
+  final CancellableValueChanged<bool>? onExpansion;
   final bool showStar;
   final List<Dice> dice;
   final Iterable<Widget> chips;
@@ -124,10 +125,14 @@ class _DynamicActionCardState extends State<DynamicActionCard> {
             ),
             key: widget.expansionKey,
             onExpansion: (val) {
+              final cancel = widget.onExpansion?.call(val) ?? false;
+              if (cancel) {
+                return true;
+              }
               setState(() {
                 expanded = val;
               });
-              widget.onExpansion?.call(val);
+              return cancel;
             },
             initiallyExpanded: widget.initiallyExpanded ?? false,
             iconColor: Theme.of(context).colorScheme.secondary,

--- a/lib/app/widgets/cards/item_card.dart
+++ b/lib/app/widgets/cards/item_card.dart
@@ -1,3 +1,4 @@
+import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_tile.dart';
 import 'package:dungeon_paper/app/widgets/chips/item_amount_chip.dart';
 import 'package:dungeon_paper/app/widgets/chips/item_armor_chip.dart';
 import 'package:dungeon_paper/app/widgets/chips/item_damage_chip.dart';
@@ -21,6 +22,7 @@ class ItemCard extends StatelessWidget {
     this.expansionKey,
     this.maxContentHeight,
     this.expandable = true,
+    this.onExpansion,
     this.highlightWords = const [],
     this.reorderablePadding = false,
   }) : super(key: key);
@@ -35,6 +37,7 @@ class ItemCard extends StatelessWidget {
   final PageStorageKey? expansionKey;
   final double? maxContentHeight;
   final bool expandable;
+  final CancellableValueChanged<bool>? onExpansion;
   final List<String> highlightWords;
   final bool reorderablePadding;
 
@@ -46,6 +49,7 @@ class ItemCard extends StatelessWidget {
       description: item.description,
       maxContentHeight: maxContentHeight,
       expandable: expandable,
+      onExpansion: onExpansion,
       explanation: '',
       reorderablePadding: reorderablePadding,
       leading: [

--- a/lib/app/widgets/cards/move_card.dart
+++ b/lib/app/widgets/cards/move_card.dart
@@ -1,4 +1,5 @@
 import 'package:dungeon_paper/app/data/models/ability_scores.dart';
+import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_tile.dart';
 import 'package:dungeon_paper/app/widgets/chips/move_category_chip.dart';
 import 'package:dungeon_paper/app/widgets/chips/tag_chip.dart';
 import 'package:flutter/material.dart';
@@ -15,6 +16,7 @@ class MoveCard extends StatelessWidget {
     this.showStar = true,
     this.showIcon = true,
     this.initiallyExpanded,
+    this.onExpansion,
     this.actions = const [],
     this.expansionKey,
     this.maxContentHeight,
@@ -31,6 +33,7 @@ class MoveCard extends StatelessWidget {
   final bool showStar;
   final bool showIcon;
   final bool? initiallyExpanded;
+  final CancellableValueChanged<bool>? onExpansion;
   final Iterable<Widget> actions;
   final PageStorageKey? expansionKey;
   final double? maxContentHeight;
@@ -48,6 +51,7 @@ class MoveCard extends StatelessWidget {
       explanation: move.explanation,
       maxContentHeight: maxContentHeight,
       expandable: expandable,
+      onExpansion: onExpansion,
       reorderablePadding: reorderablePadding,
       expansionKey: expansionKey ?? PageStorageKey(move.key),
       chips: move.tags.map((t) => TagChip.openDescription(tag: t)),

--- a/lib/app/widgets/cards/note_card.dart
+++ b/lib/app/widgets/cards/note_card.dart
@@ -1,3 +1,4 @@
+import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_tile.dart';
 import 'package:dungeon_paper/app/widgets/chips/tag_chip.dart';
 import 'package:flutter/material.dart';
 
@@ -16,6 +17,7 @@ class NoteCard extends StatelessWidget {
     this.expansionKey,
     this.maxContentHeight,
     this.expandable = true,
+    this.onExpansion,
     this.highlightWords = const [],
     this.reorderablePadding = false,
   }) : super(key: key);
@@ -29,6 +31,7 @@ class NoteCard extends StatelessWidget {
   final PageStorageKey? expansionKey;
   final double? maxContentHeight;
   final bool expandable;
+  final CancellableValueChanged<bool>? onExpansion;
   final List<String> highlightWords;
   final bool reorderablePadding;
 
@@ -41,6 +44,7 @@ class NoteCard extends StatelessWidget {
       explanation: '',
       maxContentHeight: maxContentHeight,
       expandable: expandable,
+      onExpansion: onExpansion,
       reorderablePadding: reorderablePadding,
       chips: note.tags.map((t) => TagChip.openDescription(tag: t)),
       dice: const [],

--- a/lib/app/widgets/cards/race_card.dart
+++ b/lib/app/widgets/cards/race_card.dart
@@ -1,3 +1,4 @@
+import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_tile.dart';
 import 'package:dungeon_paper/app/widgets/chips/move_category_chip.dart';
 import 'package:dungeon_paper/app/widgets/chips/primary_chip.dart';
 import 'package:dungeon_paper/app/widgets/chips/tag_chip.dart';
@@ -18,6 +19,7 @@ class RaceCard extends StatelessWidget {
     this.expansionKey,
     this.maxContentHeight,
     this.expandable = true,
+    this.onExpansion,
     this.advancedLevelDisplay = AdvancedLevelDisplay.short,
     this.highlightWords = const [],
     this.showClasses = false,
@@ -32,6 +34,7 @@ class RaceCard extends StatelessWidget {
   final PageStorageKey? expansionKey;
   final double? maxContentHeight;
   final bool expandable;
+  final CancellableValueChanged<bool>? onExpansion;
   final AdvancedLevelDisplay advancedLevelDisplay;
   final List<String> highlightWords;
   final bool showClasses;
@@ -44,6 +47,7 @@ class RaceCard extends StatelessWidget {
       explanation: race.explanation,
       maxContentHeight: maxContentHeight,
       expandable: expandable,
+      onExpansion: onExpansion,
       expansionKey: expansionKey ?? PageStorageKey(race.key),
       chips: race.tags.map((t) => TagChip.openDescription(tag: t)),
       dice: const [],

--- a/lib/app/widgets/cards/spell_card.dart
+++ b/lib/app/widgets/cards/spell_card.dart
@@ -1,4 +1,5 @@
 import 'package:dungeon_paper/app/data/models/ability_scores.dart';
+import 'package:dungeon_paper/app/widgets/atoms/custom_expansion_tile.dart';
 import 'package:dungeon_paper/app/widgets/chips/spell_level_chip.dart';
 import 'package:flutter/material.dart';
 
@@ -18,6 +19,7 @@ class SpellCard extends StatelessWidget {
     this.expansionKey,
     this.maxContentHeight,
     this.expandable = true,
+    this.onExpansion,
     this.highlightWords = const [],
     this.abilityScores,
     this.reorderablePadding = false,
@@ -33,6 +35,7 @@ class SpellCard extends StatelessWidget {
   final PageStorageKey? expansionKey;
   final double? maxContentHeight;
   final bool expandable;
+  final CancellableValueChanged<bool>? onExpansion;
   final List<String> highlightWords;
   final AbilityScores? abilityScores;
   final bool reorderablePadding;
@@ -45,6 +48,7 @@ class SpellCard extends StatelessWidget {
       explanation: spell.explanation,
       maxContentHeight: maxContentHeight,
       expandable: expandable,
+      onExpansion: onExpansion,
       reorderablePadding: reorderablePadding,
       leading: [SpellLevelChip(level: spell.level)],
       chips: const [],

--- a/lib/app/widgets/dialogs/xp_dialog.dart
+++ b/lib/app/widgets/dialogs/xp_dialog.dart
@@ -110,6 +110,7 @@ class _EXPDialogState extends State<EXPDialog> with CharacterServiceMixin {
                       setState(() {
                         manualExpExpanded = value;
                       });
+                      return false;
                     },
                     children: [
                       HelpText(text: S.current.xpDialogOverrideInfoText),


### PR DESCRIPTION
When you have a single selection, like a race or class, clicking a tile immediately selects it

When you have multi-selections, like a spell list, clicking a tile expands it and clicking it again selects it. Then clicking it a third time collapses it.

I feel this is nicer to use. For example, creating a wizard takes 22 buttons without this change, or 18 with it. Choosing spells (if you know what you want) takes an additional 6 less actions. Also, cards take up less space, so you can see more of them at once often.