### PR TITLE
Fix offline notes when you cannot reach the server

### DIFF
--- a/lib/app/modules/Home/views/home_character_journal_view.dart
+++ b/lib/app/modules/Home/views/home_character_journal_view.dart
@@ -110,7 +110,6 @@ class HomeCharacterJournalView extends GetView<CharacterService> {
               onPressed: () => Get.back(result: false),
               style: ButtonThemes.primaryElevated(context),
             ),
-            // const SizedBox(width: 8),
             ElevatedButton.icon(
               icon: const Icon(Icons.delete),
               label: Text(S.current.remove),

--- a/lib/app/modules/Home/views/home_view.dart
+++ b/lib/app/modules/Home/views/home_view.dart
@@ -21,7 +21,7 @@ import 'home_fab.dart';
 import 'home_nav_bar.dart';
 
 class HomeView extends GetView<CharacterService> with UserServiceMixin, LoadingServiceMixin, CharacterServiceMixin {
-  const HomeView({Key? key}) : super(key: key);
+  const HomeView({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -45,9 +45,7 @@ class HomeView extends GetView<CharacterService> with UserServiceMixin, LoadingS
                   : const HomeEmptyState();
         },
       ),
-      floatingActionButton: Obx(
-        () => userService.isLoggedIn && maybeChar != null ? const HomeFAB() : const SizedBox.shrink(),
-      ),
+      floatingActionButton: Obx(() => maybeChar != null ? const HomeFAB() : const SizedBox.shrink()),
       bottomNavigationBar: Obx(
         () => maybeChar != null ? HomeNavBar(pageController: controller.pageController) : const SizedBox.shrink(),
       ),
@@ -93,7 +91,7 @@ class HomeEmptyState extends StatelessWidget with UserServiceMixin {
                           text: TextSpan(
                             children: [
                               IconSpan(context, icon: Icons.person, size: 24),
-                              TextSpan(text: ' ' + S.current.homeEmptyStateLoginTitle),
+                              TextSpan(text: ' ${S.current.homeEmptyStateLoginTitle}'),
                             ],
                             style: textTheme.titleLarge,
                           ),


### PR DESCRIPTION
This doesn't matter now (except for my fork where the server doesn't respond). But in the future, it would be nice if the app worked fully offline, and this should make that more feasible.